### PR TITLE
Hide API endpoint list

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -28,22 +28,6 @@ app.use(`${basePath}/rooms`, payload);
 app.use(`${basePath}/devices`, device);
 app.use(`${basePath}/blocks`, block);
 
-app.get('/', (req, res) => {
-  return res.status(STATUS_CODES.OK).json({
-    statusCode: res.statusCode,
-    message: 'Available endpoints',
-    endpoints: {
-      api_path: `${basePath}`,
-      webhook: `[POST]: ${basePath}/integrations/webhook`,
-      all_device_info: `[GET]: ${basePath}/devices`,
-      single_device_info: `[GET]: ${basePath}/devices/{dev_eui}`,
-      device_history_info: `[GET]: ${basePath}/rooms/history/{dev_eui}`,
-      recent_room_data: `[GET]: ${basePath}/rooms/latest/{dev_eui}`,
-      all_room_data: `[GET]: ${basePath}/rooms/{dev_eui}`,
-    },
-  });
-});
-
 const server = app.listen(port, () => {
   console.log(`Server running on port ${port}`);
 });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,7 +4,6 @@ import cors from 'cors';
 import helmet from 'helmet';
 
 import { INDEX_PATHS, PORTS } from './utils/constants/globalConstants.js';
-import { STATUS_CODES } from './utils/statusCodes/statusCode.js';
 import { webhookRouter as webhook } from './routes/webhook/webhook.route.js';
 import payload from './routes/sensorData/sensorData.route.js';
 import device from './routes/devices/device.route.js';


### PR DESCRIPTION
Partial solves issue #142 

Will probably need some re-working of how the endpoints are accessed, to hide the data even more.  

For now, this removes the list of available endpoints from hitting the base backend URL.
