### PR TITLE
Displaying blocks in alphabetical order

### DIFF
--- a/frontend/src/Component/Pages/Homepage.jsx
+++ b/frontend/src/Component/Pages/Homepage.jsx
@@ -4,27 +4,25 @@ import { useGetBlockList } from '../../Hooks/Blocks/useGetBlockList';
 const apiKey = import.meta.env.VITE_BACKEND_API_KEY;
 
 export const Homepage = () => {
-  const {blocks} = useGetBlockList(`${apiKey}/api/v1/blocks`);
+  const { blocks } = useGetBlockList(`${apiKey}/api/v1/blocks`);
 
   return (
     <>
       {blocks && (
         <div className="grid justify-items-center grid-cols-3 md:grid-cols-2 md:justify-items-stretch md:mx-2 lg:grid-cols-4 gap-4 mt-4">
           {blocks.map((block) => (
-            <div
-              key={block.blockName}
-              className="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100"
+            <NavLink
+              to={`${block.blockName}`}
+              className="link"
+              data-cy={block.blockName}
             >
-              <li className='text-center'>
-                <NavLink
-                  to={`${block.blockName}`}
-                  className="link"
-                  data-cy={block.blockName}
-                >
-                  {block.blockName}
-                </NavLink>
-              </li>
-            </div>
+              <div
+                key={block.blockName}
+                className="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100"
+              >
+                <li className="text-center">{block.blockName}</li>
+              </div>
+            </NavLink>
           ))}
         </div>
       )}

--- a/frontend/src/Hooks/Blocks/useGetBlockList.js
+++ b/frontend/src/Hooks/Blocks/useGetBlockList.js
@@ -15,7 +15,10 @@ export const useGetBlockList = (apiKey) => {
           blockName: item.blockName
         };
       });
-      setBlocks(mappedData);
+
+      const sortedData = mappedData.sort((a, b) => a.blockName.localeCompare(b.blockName));
+
+      setBlocks(sortedData);
     } catch (error) {
       setApiError(error.message);
     }


### PR DESCRIPTION
The blocks on the block page are now ordered in alphabetical order.
![image](https://github.com/user-attachments/assets/67da0e5e-0da0-4aa3-a1e3-e52f291023b4)
